### PR TITLE
twilio: add new SuperSim client, support SuperSim API

### DIFF
--- a/http.go
+++ b/http.go
@@ -55,6 +55,10 @@ const NotifyVersion = "v1"
 const LookupBaseURL = "https://lookups.twilio.com"
 const LookupVersion = "v1"
 
+// Super sim service
+var SuperSimBaseUrl = "https://supersim.twilio.com"
+var SuperSimVersion = "v1"
+
 // Verify service
 const VerifyBaseURL = "https://verify.twilio.com"
 const VerifyVersion = "v2"
@@ -85,6 +89,7 @@ type Client struct {
 	Video      *Client
 	TaskRouter *Client
 	Insights   *Client
+	SuperSim   *Client
 
 	// FullPath takes a path part (e.g. "Messages") and
 	// returns the full API path, including the version (e.g.
@@ -125,6 +130,9 @@ type Client struct {
 	// NewWirelessClient initializes these services
 	Sims     *SimService
 	Commands *CommandService
+
+	// NewSuperSimClient initializes these services
+	SuperSims *SuperSimService
 
 	// NewNotifyClient initializes these services
 	Credentials *NotifyCredentialsService
@@ -238,6 +246,14 @@ func NewWirelessClient(accountSid string, authToken string, httpClient *http.Cli
 	c.APIVersion = WirelessVersion
 	c.Sims = &SimService{client: c}
 	c.Commands = &CommandService{client: c}
+	return c
+}
+
+// NewSuperSimClient returns a Client for use with the Twilio SuperSim API.
+func NewSuperSimClient(accountSid string, authToken string, httpClient *http.Client) *Client {
+	c := newNewClient(accountSid, authToken, SuperSimBaseUrl, httpClient)
+	c.APIVersion = SuperSimVersion
+	c.SuperSims = &SuperSimService{client: c}
 	return c
 }
 
@@ -378,6 +394,7 @@ func NewClient(accountSid string, authToken string, httpClient *http.Client) *Cl
 	c.Video = NewVideoClient(accountSid, authToken, httpClient)
 	c.TaskRouter = NewTaskRouterClient(accountSid, authToken, httpClient)
 	c.Insights = NewInsightsClient(accountSid, authToken, httpClient)
+	c.SuperSim = NewSuperSimClient(accountSid, authToken, httpClient)
 
 	c.Accounts = &AccountService{client: c}
 	c.Applications = &ApplicationService{client: c}

--- a/responses_test.go
+++ b/responses_test.go
@@ -66,6 +66,7 @@ func getServer(response []byte) (*Client, *Server) {
 	client.Video.Base = s.URL
 	client.TaskRouter.Base = s.URL
 	client.Insights.Base = s.URL
+	client.SuperSim.Base = s.URL
 	return client, s
 }
 
@@ -81,6 +82,7 @@ func getServerCode(response []byte, code int) (*Client, *Server) {
 	client.Lookup.Base = s.URL
 	client.Video.Base = s.URL
 	client.TaskRouter.Base = s.URL
+	client.SuperSim.Base = s.URL
 	return client, s
 }
 
@@ -3383,6 +3385,274 @@ var insightsCallMetricsResponse = []byte(`
         "next_page_url": null,
         "key": "metrics"
     }
+}
+`)
+
+var superSimResponse = []byte(`
+{
+   "date_updated" : "2021-04-21T20:50:47Z",
+   "fleet_sid" : "HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+   "status" : "new",
+   "date_created" : "2021-04-21T20:50:47Z",
+   "sid" : "HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+   "account_sid" : "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+   "unique_name" : "The Best Sim",
+   "url" : "https://supersim.twilio.com/v1/Sims/HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+   "iccid" : "89883070000010223806"
+}
+`)
+
+var superSimPageResponse = []byte(`
+{
+   "sims" : [
+      {
+         "date_updated" : "2021-04-21T20:50:47Z",
+         "url" : "https://supersim.twilio.com/v1/Sims/HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+         "unique_name" : "Sim1",
+         "iccid" : "89883070000010223806",
+         "status" : "new",
+         "date_created" : "2021-04-21T20:50:47Z",
+         "sid" : "HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+         "fleet_sid" : "HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+         "account_sid" : "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+      },
+      {
+         "status" : "new",
+         "date_created" : "2021-04-21T20:50:47Z",
+         "sid" : "HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+         "fleet_sid" : "HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+         "account_sid" : "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+         "date_updated" : "2021-04-21T20:50:47Z",
+         "url" : "https://supersim.twilio.com/v1/Sims/HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+         "unique_name" : "Sim2",
+         "iccid" : "89883070000010223798"
+      },
+      {
+         "sid" : "HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+         "fleet_sid" : "HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+         "account_sid" : "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+         "status" : "new",
+         "date_created" : "2021-04-21T20:50:47Z",
+         "unique_name" : "Sim3",
+         "iccid" : "89883070000010223780",
+         "date_updated" : "2021-04-21T20:50:47Z",
+         "url" : "https://supersim.twilio.com/v1/Sims/HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+      },
+      {
+         "status" : "new",
+         "date_created" : "2021-04-21T20:50:47Z",
+         "sid" : "HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+         "fleet_sid" : "HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+         "account_sid" : "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+         "date_updated" : "2021-04-21T20:50:47Z",
+         "url" : "https://supersim.twilio.com/v1/Sims/HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+         "unique_name" : "Sim4",
+         "iccid" : "89883070000010223772"
+      },
+      {
+         "date_created" : "2021-04-21T20:50:47Z",
+         "status" : "new",
+         "fleet_sid" : "HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+         "account_sid" : "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+         "sid" : "HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+         "url" : "https://supersim.twilio.com/v1/Sims/HSXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+         "date_updated" : "2021-04-21T20:50:47Z",
+         "iccid" : "89883070000010223764",
+         "unique_name" : "Sim5"
+      }
+   ],
+   "meta" : {
+      "next_page_url" : "https://supersim.twilio.com/v1/Sims?PageSize=5&Page=1&PageToken=FAKETOKEN",
+      "previous_page_url" : null,
+      "url" : "https://supersim.twilio.com/v1/Sims?PageSize=5&Page=0",
+      "first_page_url" : "https://supersim.twilio.com/v1/Sims?PageSize=5&Page=0",
+      "page" : 0,
+      "page_size" : 5,
+      "key" : "sims"
+   }
+}
+`)
+
+var fleetResponse = []byte(`
+{
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "unique_name": "unique_name",
+  "data_enabled": true,
+  "data_limit": 1000,
+  "data_metering": "payg",
+  "date_created": "2019-07-30T20:00:00Z",
+  "date_updated": "2019-07-30T20:00:00Z",
+  "commands_enabled": true,
+  "commands_method": "GET",
+  "commands_url": "https://google.com",
+  "sms_commands_enabled": true,
+  "sms_commands_method": "GET",
+  "sms_commands_url": "https://google.com",
+  "ip_commands_method": "GET",
+  "ip_commands_url": "https://google.com",
+  "network_access_profile_sid": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "sid": "HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "url": "https://supersim.twilio.com/v1/Fleets/HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+}
+`)
+
+var fleetPageResponse = []byte(`
+{
+   "fleets" : [
+      {
+		"account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		"unique_name": "unique_name",
+		"data_enabled": true,
+		"data_limit": 1000,
+		"data_metering": "payg",
+		"date_created": "2019-07-30T20:00:00Z",
+		"date_updated": "2019-07-30T20:00:00Z",
+		"commands_enabled": true,
+		"commands_method": "GET",
+		"commands_url": "https://google.com",
+		"sms_commands_enabled": true,
+		"sms_commands_method": "GET",
+		"sms_commands_url": "https://google.com",
+		"ip_commands_method": "GET",
+		"ip_commands_url": "https://google.com",
+		"network_access_profile_sid": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		"sid": "HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		"url": "https://supersim.twilio.com/v1/Fleets/HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+	  },
+      {
+		"account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		"unique_name": "unique_name",
+		"data_enabled": true,
+		"data_limit": 1000,
+		"data_metering": "payg",
+		"date_created": "2019-07-30T20:00:00Z",
+		"date_updated": "2019-07-30T20:00:00Z",
+		"commands_enabled": true,
+		"commands_method": "GET",
+		"commands_url": "https://google.com",
+		"sms_commands_enabled": true,
+		"sms_commands_method": "GET",
+		"sms_commands_url": "https://google.com",
+		"ip_commands_method": "GET",
+		"ip_commands_url": "https://google.com",
+		"network_access_profile_sid": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		"sid": "HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		"url": "https://supersim.twilio.com/v1/Fleets/HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+	  },
+      {
+		"account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		"unique_name": "unique_name",
+		"data_enabled": true,
+		"data_limit": 1000,
+		"data_metering": "payg",
+		"date_created": "2019-07-30T20:00:00Z",
+		"date_updated": "2019-07-30T20:00:00Z",
+		"commands_enabled": true,
+		"commands_method": "GET",
+		"commands_url": "https://google.com",
+		"sms_commands_enabled": true,
+		"sms_commands_method": "GET",
+		"sms_commands_url": "https://google.com",
+		"ip_commands_method": "GET",
+		"ip_commands_url": "https://google.com",
+		"network_access_profile_sid": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		"sid": "HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		"url": "https://supersim.twilio.com/v1/Fleets/HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+	  },
+      {
+		"account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		"unique_name": "unique_name",
+		"data_enabled": true,
+		"data_limit": 1000,
+		"data_metering": "payg",
+		"date_created": "2019-07-30T20:00:00Z",
+		"date_updated": "2019-07-30T20:00:00Z",
+		"commands_enabled": true,
+		"commands_method": "GET",
+		"commands_url": "https://google.com",
+		"sms_commands_enabled": true,
+		"sms_commands_method": "GET",
+		"sms_commands_url": "https://google.com",
+		"ip_commands_method": "GET",
+		"ip_commands_url": "https://google.com",
+		"network_access_profile_sid": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		"sid": "HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		"url": "https://supersim.twilio.com/v1/Fleets/HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+	  },
+      {
+		  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		  "unique_name": "unique_name",
+		  "data_enabled": true,
+		  "data_limit": 1000,
+		  "data_metering": "payg",
+		  "date_created": "2019-07-30T20:00:00Z",
+		  "date_updated": "2019-07-30T20:00:00Z",
+		  "commands_enabled": true,
+		  "commands_method": "GET",
+		  "commands_url": "https://google.com",
+		  "sms_commands_enabled": true,
+		  "sms_commands_method": "GET",
+		  "sms_commands_url": "https://google.com",
+		  "ip_commands_method": "GET",
+		  "ip_commands_url": "https://google.com",
+		  "network_access_profile_sid": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		  "sid": "HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+		  "url": "https://supersim.twilio.com/v1/Fleets/HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+		}
+   ],
+   "meta" : {
+      "next_page_url" : "https://supersim.twilio.com/v1/Fleets?PageSize=5&Page=1&PageToken=FAKETOKEN",
+      "previous_page_url" : null,
+      "url" : "https://supersim.twilio.com/v1/Fleets?PageSize=5&Page=0",
+      "first_page_url" : "https://supersim.twilio.com/v1/Fleets?PageSize=5&Page=0",
+      "page" : 0,
+      "page_size" : 5,
+      "key" : "fleets"
+   }
+}
+`)
+
+var usageRecordResponse = []byte(`
+{
+  "usage_records": [
+    {
+      "period": {
+        "start_time": "2015-05-01T20:00:00Z",
+        "end_time": "2015-06-01T20:00:00Z"
+      },
+      "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "data_upload": 1000,
+      "data_download": 1000,
+      "data_total": 2000,
+      "sim_sid": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "fleet_sid": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "network_sid": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "iso_country": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    },
+    {
+      "period": {
+        "start_time": "2015-05-01T20:00:00Z",
+        "end_time": "2015-06-01T20:00:00Z"
+      },
+      "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "data_upload": 1000,
+      "data_download": 1000,
+      "data_total": 2000,
+      "sim_sid": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "fleet_sid": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "network_sid": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "iso_country": "US"
+    }
+  ],
+  "meta": {
+    "first_page_url": "https://supersim.twilio.com/v1/UsageRecords?PageSize=50&Page=0",
+    "key": "usage_records",
+    "next_page_url": "https://supersim.twilio.com/v1/UsageRecords?PageSize=50&Page=1",
+    "page": 0,
+    "page_size": 50,
+    "previous_page_url": "https://supersim.twilio.com/v1/UsageRecords?PageSize=50&Page=0",
+    "url": "https://supersim.twilio.com/v1/UsageRecords?PageSize=50&Page=0"
+  }
 }
 `)
 

--- a/super_sim.go
+++ b/super_sim.go
@@ -1,0 +1,235 @@
+package twilio
+
+import (
+	"context"
+	"net/url"
+)
+
+const superSimPathPart = "Sims"
+const fleetPathPart = "Fleets"
+const usageRecordPathPart = "UsageRecords"
+
+type SuperSimService struct {
+	client *Client
+}
+
+type SuperSim struct {
+	Sid         string     `json:"sid"`
+	Status      string     `json:"status"`
+	DateCreated TwilioTime `json:"date_created"`
+	DateUpdated TwilioTime `json:"date_updated"`
+	AccountSid  string     `json:"account_sid"`
+	UniqueName  string     `json:"unique_name"`
+	Iccid       string     `json:"iccid"`
+	FleetSid    string     `json:"fleet_sid"`
+	Url         string     `json:"url"`
+}
+
+// SuperSimPage represents a page of SuperSims.
+type SuperSimPage struct {
+	Meta      Meta        `json:"meta"`
+	SuperSims []*SuperSim `json:"sims"`
+}
+
+type superSimPageIterator struct {
+	p *PageIterator
+}
+
+// Register registers a new SIM with the provided account.
+//
+// See https://www.twilio.com/docs/iot/supersim/api/sim-resource#add-a-super-sim-to-your-account
+func (s *SuperSimService) Register(ctx context.Context, iccid, registrationCode string) (*SuperSim, error) {
+	superSim := new(SuperSim)
+	data := url.Values{}
+	data.Set("Iccid", iccid)
+	data.Set("RegistrationCode", registrationCode)
+	err := s.client.CreateResource(ctx, superSimPathPart, data, superSim)
+	return superSim, err
+}
+
+// Get finds a single SuperSim resource by its sid or unique name, or returns an error.
+func (s *SuperSimService) Get(ctx context.Context, sidOrUniqueName string) (*SuperSim, error) {
+	superSim := new(SuperSim)
+	err := s.client.GetResource(ctx, superSimPathPart, sidOrUniqueName, superSim)
+	return superSim, err
+}
+
+// Activate sets the status of the SIM provided to "active".
+//
+// See https://www.twilio.com/docs/iot/supersim/api/sim-resource#update-a-sim-resource
+func (s *SuperSimService) Activate(ctx context.Context, sid string) (*SuperSim, error) {
+	superSim := new(SuperSim)
+	data := url.Values{}
+	data.Set("Status", "active")
+	err := s.client.UpdateResource(ctx, superSimPathPart, sid, data, superSim)
+	return superSim, err
+}
+
+// Update updates the specified SuperSim resource with the data provided, or returns an error.
+func (s *SuperSimService) Update(ctx context.Context, sid string, data url.Values) (*SuperSim, error) {
+	superSim := new(SuperSim)
+	err := s.client.UpdateResource(ctx, superSimPathPart, sid, data, superSim)
+	return superSim, err
+}
+
+// GetPage returns a single Page of SuperSims, filtered by data.
+//
+// See https://www.twilio.com/docs/iot/supersim/api/sim-resource#read-multiple-sim-resources.
+func (s *SuperSimService) GetPage(ctx context.Context, data url.Values) (*SuperSimPage, error) {
+	return s.GetPageIterator(data).Next(ctx)
+}
+
+// GetPageIterator returns a superSimPageIterator with the given page
+// filters. Call iterator.Next() to get the first page of resources (and again
+// to retrieve subsequent pages).
+func (s *SuperSimService) GetPageIterator(data url.Values) *superSimPageIterator {
+	iter := NewPageIterator(s.client, data, superSimPathPart)
+	return &superSimPageIterator{
+		p: iter,
+	}
+}
+
+// Next returns the next page of resources. If there are no more resources,
+// NoMoreResults is returned.
+func (s *superSimPageIterator) Next(ctx context.Context) (*SuperSimPage, error) {
+	ap := new(SuperSimPage)
+	err := s.p.Next(ctx, ap)
+	if err != nil {
+		return nil, err
+	}
+	s.p.SetNextPageURI(ap.Meta.NextPageURL)
+	return ap, nil
+}
+
+type Fleet struct {
+	Sid                     string     `json:"sid"`
+	Url                     string     `json:"url"`
+	AccountSid              string     `json:"account_sid"`
+	UniqueName              string     `json:"unique_name""`
+	DataEnabled             bool       `json:"data_enabled"`
+	DataLimit               int64      `json:"data_limit"`
+	DataMetering            string     `json:"data_metering"`
+	DateCreated             TwilioTime `json:"date_created"`
+	DateUpdated             TwilioTime `json:"date_updated"`
+	CommandsEnabled         bool       `json:"commands_enabled"`
+	CommandsUrl             string     `json:"commands_url"`
+	CommandsMethod          string     `json:"commands_method"`
+	SmsCommandsEnabled      bool       `json:"sms_commands_enabled"`
+	SmsCommandsMethod       string     `json:"sms_commands_method"`
+	IPCommandsMethod        string     `json:"ip_commands_method"`
+	IPCommandsUrl           string     `json:"ip_commands_url"`
+	NetworkAccessProfileSid string     `json:"network_access_profile_sid"`
+}
+
+// FleetPage represents a page of Fleets.
+type FleetPage struct {
+	Meta   Meta     `json:"meta"`
+	Fleets []*Fleet `json:"fleets"`
+}
+
+type fleetPageIterator struct {
+	p *PageIterator
+}
+
+// Create creates a new SuperSim Fleet with the data provided, or returns an error.
+func (s *SuperSimService) CreateFleet(ctx context.Context, data url.Values) (*Fleet, error) {
+	fleet := new(Fleet)
+	err := s.client.CreateResource(ctx, fleetPathPart, data, fleet)
+	return fleet, err
+}
+
+// Get finds a single SuperSim Fleet by its sid, or returns an error.
+func (s *SuperSimService) GetFleet(ctx context.Context, sid string) (*Fleet, error) {
+	fleet := new(Fleet)
+	err := s.client.GetResource(ctx, fleetPathPart, sid, fleet)
+	return fleet, err
+}
+
+// GetPage returns a single Page of fleets, filtered by data.
+//
+// See https://www.twilio.com/docs/iot/supersim/api/fleet-resource#read-multiple-fleet-resources.
+func (s *SuperSimService) GetFleetPage(ctx context.Context, data url.Values) (*FleetPage, error) {
+	return s.GetFleetPageIterator(data).Next(ctx)
+}
+
+// GetFleetPageIterator returns a fleetPageIterator with the given page
+// filters. Call iterator.Next() to get the first page of resources (and again
+// to retrieve subsequent pages).
+func (s *SuperSimService) GetFleetPageIterator(data url.Values) *fleetPageIterator {
+	iter := NewPageIterator(s.client, data, fleetPathPart)
+	return &fleetPageIterator{
+		p: iter,
+	}
+}
+
+// Next returns the next page of resources. If there are no more resources,
+// NoMoreResults is returned.
+func (s *fleetPageIterator) Next(ctx context.Context) (*FleetPage, error) {
+	ap := new(FleetPage)
+	err := s.p.Next(ctx, ap)
+	if err != nil {
+		return nil, err
+	}
+	s.p.SetNextPageURI(ap.Meta.NextPageURL)
+	return ap, nil
+}
+
+type UsageRecord struct {
+	AccountSid string `json:"account_sid"`
+	SimSid     string `json:"sim_sid"`
+	FleetSid   string `json:"fleet_sid"`
+	NetworkSid string `json:"network_sid"`
+	// Total data uploaded in bytes, aggregated by the query parameters
+	DataUpload int64 `json:"data_upload"`
+	// Total data downloaded in bytes, aggregated by the query parameters
+	DataDownload int64 `json:"data_download"`
+	// Total of data_upload and data_download (in bytes).
+	DataTotal int64 `json:"data_total"`
+	// Alpha-2 ISO Country Code
+	IsoCountry string              `json:"iso_country"`
+	Period     SuperSimUsagePeriod `json:"period"`
+}
+
+type SuperSimUsagePeriod struct {
+	Start TwilioTime `json:"start_time"`
+	End   TwilioTime `json:"end_time"`
+}
+
+// UsageRecordPage represents a page of UsageRecords.
+type UsageRecordPage struct {
+	Meta         Meta           `json:"meta"`
+	UsageRecords []*UsageRecord `json:"usage_records"`
+}
+
+type UsageRecordPageIterator struct {
+	p *PageIterator
+}
+
+// GetPage returns a single Page of UsageRecords, filtered by data.
+//
+// See https://www.twilio.com/docs/iot/supersim/api/usage-record-resource#read-usagerecord-resources.
+func (s *SuperSimService) GetUsageRecordPage(ctx context.Context, data url.Values) (*UsageRecordPage, error) {
+	return s.GetUsageRecordPageIterator(data).Next(ctx)
+}
+
+// GetPageIterator returns a UsageRecordPageIterator with the given page
+// filters. Call iterator.Next() to get the first page of resources (and again
+// to retrieve subsequent pages).
+func (s *SuperSimService) GetUsageRecordPageIterator(data url.Values) *UsageRecordPageIterator {
+	iter := NewPageIterator(s.client, data, usageRecordPathPart)
+	return &UsageRecordPageIterator{
+		p: iter,
+	}
+}
+
+// Next returns the next page of resources. If there are no more resources,
+// NoMoreResults is returned.
+func (s *UsageRecordPageIterator) Next(ctx context.Context) (*UsageRecordPage, error) {
+	ap := new(UsageRecordPage)
+	err := s.p.Next(ctx, ap)
+	if err != nil {
+		return nil, err
+	}
+	s.p.SetNextPageURI(ap.Meta.NextPageURL)
+	return ap, nil
+}

--- a/super_sim_test.go
+++ b/super_sim_test.go
@@ -1,0 +1,304 @@
+package twilio
+
+import (
+	"context"
+	"net/url"
+	"testing"
+)
+
+func assertSuperSimExpected(t *testing.T, sim *SuperSim) {
+	if sim == nil {
+		t.Fatal("SuperSim unexpectedly nil")
+	}
+	if sim.Sid == "" {
+		t.Error("expected Sid to be populated")
+	}
+	if sim.FleetSid == "" {
+		t.Error("expected FleetSid to be populated")
+	}
+	if sim.UniqueName == "" {
+		t.Error("expected UniqueName to be populated")
+	}
+	if sim.Status == "" {
+		t.Error("expected Status to be populated")
+	}
+	if !sim.DateCreated.Valid {
+		t.Error("expected DateCreated to be valid")
+	}
+	if !sim.DateUpdated.Valid {
+		t.Error("expected DateUpdated to be valid")
+	}
+	if sim.AccountSid == "" {
+		t.Error("expected AccountSid to be populated")
+	}
+	if sim.Iccid == "" {
+		t.Error("expected Iccid to be populated")
+	}
+	if sim.Url == "" {
+		t.Error("expected Url to be populated")
+	}
+}
+
+func assertFleetExpected(t *testing.T, fleet *Fleet) {
+	if fleet.AccountSid == "" {
+		t.Error("expected AccountSid to be populated")
+	}
+	if fleet.UniqueName == "" {
+		t.Error("expected AccountSid to be populated")
+	}
+	if !fleet.DataEnabled {
+		t.Error("expected DataEnabled to be true")
+	}
+	if fleet.DataLimit == 0 {
+		t.Error("expected DataLimit to be populated")
+	}
+	if fleet.DataMetering == "" {
+		t.Error("expected DataMetering to be populated")
+	}
+	if !fleet.DateCreated.Valid {
+		t.Error("expected DateCreated to be valid")
+	}
+	if !fleet.DateUpdated.Valid {
+		t.Error("expected DateUpdated to be valid")
+	}
+	if !fleet.CommandsEnabled {
+		t.Error("expected CommandsEnabled to be true")
+	}
+	if fleet.CommandsMethod == "" {
+		t.Error("expected CommandsMethod to be present")
+	}
+	if fleet.CommandsUrl == "" {
+		t.Error("expected CommandsUrl to be present")
+	}
+	if !fleet.SmsCommandsEnabled {
+		t.Error("expected SmsCommandsEnabled to be true")
+	}
+	if fleet.SmsCommandsMethod == "" {
+		t.Error("expected SmsCommandsMethod to be present")
+	}
+	if fleet.IPCommandsUrl == "" {
+		t.Error("expected IPCommandsUrl to be present")
+	}
+	if fleet.IPCommandsMethod == "" {
+		t.Error("expected IPCommandsMethod to be present")
+	}
+	if fleet.NetworkAccessProfileSid == "" {
+		t.Error("expected NetworkAccessProfileSid to be present")
+	}
+	if fleet.Sid == "" {
+		t.Error("expected Sid to be present")
+	}
+	if fleet.Url == "" {
+		t.Error("expected Sid to be present")
+	}
+}
+
+func assertUsageRecordExpected(t *testing.T, usageRecord *UsageRecord) {
+	if usageRecord == nil {
+		t.Fatal("SuperSim unexpectedly nil")
+	}
+	if usageRecord.SimSid == "" {
+		t.Error("expected SimSid to be populated")
+	}
+	if usageRecord.AccountSid == "" {
+		t.Error("expected AccountSid to be populated")
+	}
+	if usageRecord.FleetSid == "" {
+		t.Error("expected FleetSid to be populated")
+	}
+	if usageRecord.NetworkSid == "" {
+		t.Error("expected NetworkSid to be populated")
+	}
+	if usageRecord.IsoCountry == "" {
+		t.Error("expected IsoCountry to be populated")
+	}
+	if usageRecord.FleetSid == "" {
+		t.Error("expected FleetSid to be populated")
+	}
+	if !usageRecord.Period.Start.Valid {
+		t.Error("expected Period Start time to be populated")
+	}
+	if !usageRecord.Period.End.Valid {
+		t.Error("expected Period End time to be populated")
+	}
+	if usageRecord.DataDownload == 0 {
+		t.Error("expected DataDownload to be populated")
+	}
+	if usageRecord.DataUpload == 0 {
+		t.Error("expected DataUpload to be populated")
+	}
+	if usageRecord.DataTotal == 0 {
+		t.Error("expected DataTotal to be populated")
+	}
+}
+
+func assertPageExpected(t *testing.T, meta Meta) {
+	if meta.FirstPageURL == "" {
+		t.Error("expected FirstPageURL to be populated")
+	}
+	if meta.Key == "" {
+		t.Error("expected Key to be populated")
+	}
+	if meta.PageSize == 0 {
+		t.Error("expected default PageSize, got 0")
+	}
+}
+
+func TestSuperSim(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Register", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(superSimResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		superSim, err := client.SuperSim.SuperSims.Register(ctx, "89883070000123456789", "code")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertSuperSimExpected(t, superSim)
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(superSimResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		superSim, err := client.SuperSim.SuperSims.Get(ctx, "HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertSuperSimExpected(t, superSim)
+	})
+
+	t.Run("Activate", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(superSimResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		superSim, err := client.SuperSim.SuperSims.Activate(ctx, "HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertSuperSimExpected(t, superSim)
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(superSimResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		data := url.Values{}
+		data.Set("Status", "inactive")
+		superSim, err := client.SuperSim.SuperSims.Update(ctx, "HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertSuperSimExpected(t, superSim)
+	})
+
+	t.Run("GetPage", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(superSimPageResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		data := url.Values{}
+		data.Set("Status", "active")
+		resp, err := client.SuperSim.SuperSims.GetPage(ctx, url.Values{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(resp.SuperSims) != 5 {
+			t.Error("expected 5 SuperSims to be returned")
+		}
+		assertPageExpected(t, resp.Meta)
+		for _, sim := range resp.SuperSims {
+			assertSuperSimExpected(t, sim)
+		}
+	})
+}
+
+func TestFleet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Create", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(fleetResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		fleet, err := client.SuperSim.SuperSims.CreateFleet(ctx, url.Values{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertFleetExpected(t, fleet)
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(fleetResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		fleet, err := client.SuperSim.SuperSims.GetFleet(ctx, "HFXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertFleetExpected(t, fleet)
+	})
+
+	t.Run("GetPage", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(fleetPageResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		resp, err := client.SuperSim.SuperSims.GetFleetPage(ctx, url.Values{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(resp.Fleets) != 5 {
+			t.Errorf("expected 5 fleets, get %d", len(resp.Fleets))
+		}
+		for _, fleet := range resp.Fleets {
+			assertFleetExpected(t, fleet)
+		}
+		assertPageExpected(t, resp.Meta)
+	})
+}
+
+func TestUsageRecords(t *testing.T) {
+	t.Parallel()
+	t.Run("GetPage", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(usageRecordResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		resp, err := client.SuperSim.SuperSims.GetUsageRecordPage(ctx, url.Values{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(resp.UsageRecords) != 2 {
+			t.Errorf("expected 2 usage records, got %d", len(resp.UsageRecords))
+		}
+		for _, usageRecord := range resp.UsageRecords {
+			assertUsageRecordExpected(t, usageRecord)
+		}
+		assertPageExpected(t, resp.Meta)
+	})
+}


### PR DESCRIPTION
Add a new `SuperSim` client that initializes a `SuperSimService`. The `SuperSimService` handles API calls for the `SuperSim` resource, the `Fleet` resource (a collection of `SuperSim`s), and the `UsageRecord` resource.

The `SuperSim` client will be extended to add support for `SuperSim` networks and commands.