### PR TITLE
twilio: add new NetworkService to SuperSim client

### DIFF
--- a/http.go
+++ b/http.go
@@ -55,6 +55,10 @@ const NotifyVersion = "v1"
 const LookupBaseURL = "https://lookups.twilio.com"
 const LookupVersion = "v1"
 
+// Super sim service
+var SuperSimBaseUrl = "https://supersim.twilio.com"
+var SuperSimVersion = "v1"
+
 // Verify service
 const VerifyBaseURL = "https://verify.twilio.com"
 const VerifyVersion = "v2"
@@ -85,6 +89,7 @@ type Client struct {
 	Video      *Client
 	TaskRouter *Client
 	Insights   *Client
+	SuperSim   *Client
 
 	// FullPath takes a path part (e.g. "Messages") and
 	// returns the full API path, including the version (e.g.
@@ -125,6 +130,9 @@ type Client struct {
 	// NewWirelessClient initializes these services
 	Sims     *SimService
 	Commands *CommandService
+
+	// NewSuperSimClient initializes these services
+	SuperSims *SuperSimService
 
 	// NewNotifyClient initializes these services
 	Credentials *NotifyCredentialsService
@@ -238,6 +246,14 @@ func NewWirelessClient(accountSid string, authToken string, httpClient *http.Cli
 	c.APIVersion = WirelessVersion
 	c.Sims = &SimService{client: c}
 	c.Commands = &CommandService{client: c}
+	return c
+}
+
+// NewSuperSimClient returns a Client for use with the Twilio SuperSim API.
+func NewSuperSimClient(accountSid string, authToken string, httpClient *http.Client) *Client {
+	c := newNewClient(accountSid, authToken, SuperSimBaseUrl, httpClient)
+	c.APIVersion = SuperSimVersion
+	c.SuperSims = &SuperSimService{client: c}
 	return c
 }
 
@@ -378,6 +394,7 @@ func NewClient(accountSid string, authToken string, httpClient *http.Client) *Cl
 	c.Video = NewVideoClient(accountSid, authToken, httpClient)
 	c.TaskRouter = NewTaskRouterClient(accountSid, authToken, httpClient)
 	c.Insights = NewInsightsClient(accountSid, authToken, httpClient)
+	c.SuperSim = NewSuperSimClient(accountSid, authToken, httpClient)
 
 	c.Accounts = &AccountService{client: c}
 	c.Applications = &ApplicationService{client: c}

--- a/http.go
+++ b/http.go
@@ -133,6 +133,7 @@ type Client struct {
 
 	// NewSuperSimClient initializes these services
 	SuperSims *SuperSimService
+	Networks  *NetworkService
 
 	// NewNotifyClient initializes these services
 	Credentials *NotifyCredentialsService
@@ -254,6 +255,7 @@ func NewSuperSimClient(accountSid string, authToken string, httpClient *http.Cli
 	c := newNewClient(accountSid, authToken, SuperSimBaseUrl, httpClient)
 	c.APIVersion = SuperSimVersion
 	c.SuperSims = &SuperSimService{client: c}
+	c.Networks = &NetworkService{client: c}
 	return c
 }
 

--- a/super_sim.go
+++ b/super_sim.go
@@ -1,0 +1,222 @@
+package twilio
+
+import (
+	"context"
+	"net/url"
+)
+
+const superSimPathPart = "Sims"
+const fleetPathPart = "Fleets"
+const usageRecordPathPart = "UsageRecords"
+
+type SuperSimService struct {
+	client *Client
+}
+
+type SuperSim struct {
+	Sid         string     `json:"sid"`
+	Status      string     `json:"status"`
+	DateCreated TwilioTime `json:"date_created"`
+	DateUpdated TwilioTime `json:"date_updated"`
+	AccountSid  string     `json:"account_sid"`
+	UniqueName  string     `json:"unique_name"`
+	Iccid       string     `json:"iccid"`
+	FleetSid    string     `json:"fleet_sid"`
+	Url         string     `json:"url"`
+}
+
+// SuperSimPage represents a page of SuperSims.
+type SuperSimPage struct {
+	Meta      Meta        `json:"meta"`
+	SuperSims []*SuperSim `json:"sims"`
+}
+
+type superSimPageIterator struct {
+	p *PageIterator
+}
+
+// Register registers a new SIM with the provided account.
+//
+// See https://www.twilio.com/docs/iot/supersim/api/sim-resource#add-a-super-sim-to-your-account
+func (s *SuperSimService) Register(ctx context.Context, iccid, registrationCode string) (*SuperSim, error) {
+	superSim := new(SuperSim)
+	data := url.Values{}
+	data.Set("Iccid", iccid)
+	data.Set("RegistrationCode", registrationCode)
+	err := s.client.CreateResource(ctx, superSimPathPart, data, superSim)
+	return superSim, err
+}
+
+// Get finds a single SuperSim resource by its sid or unique name, or returns an error.
+func (s *SuperSimService) Get(ctx context.Context, sidOrUniqueName string) (*SuperSim, error) {
+	superSim := new(SuperSim)
+	err := s.client.GetResource(ctx, superSimPathPart, sidOrUniqueName, superSim)
+	return superSim, err
+}
+
+// Update updates the specified SuperSim resource with the data provided, or returns an error.
+func (s *SuperSimService) Update(ctx context.Context, sid string, data url.Values) (*SuperSim, error) {
+	superSim := new(SuperSim)
+	err := s.client.UpdateResource(ctx, superSimPathPart, sid, data, superSim)
+	return superSim, err
+}
+
+// GetPage returns a single Page of SuperSims, filtered by data.
+//
+// See https://www.twilio.com/docs/iot/supersim/api/sim-resource#read-multiple-sim-resources.
+func (s *SuperSimService) GetPage(ctx context.Context, data url.Values) (*SuperSimPage, error) {
+	return s.GetPageIterator(data).Next(ctx)
+}
+
+// GetPageIterator returns a superSimPageIterator with the given page
+// filters. Call iterator.Next() to get the first page of resources (and again
+// to retrieve subsequent pages).
+func (s *SuperSimService) GetPageIterator(data url.Values) *superSimPageIterator {
+	iter := NewPageIterator(s.client, data, superSimPathPart)
+	return &superSimPageIterator{
+		p: iter,
+	}
+}
+
+// Next returns the next page of resources. If there are no more resources,
+// NoMoreResults is returned.
+func (s *superSimPageIterator) Next(ctx context.Context) (*SuperSimPage, error) {
+	ap := new(SuperSimPage)
+	err := s.p.Next(ctx, ap)
+	if err != nil {
+		return nil, err
+	}
+	s.p.SetNextPageURI(ap.Meta.NextPageURL)
+	return ap, nil
+}
+
+type Fleet struct {
+	Sid                     string     `json:"sid"`
+	Url                     string     `json:"url"`
+	AccountSid              string     `json:"account_sid"`
+	UniqueName              string     `json:"unique_name""`
+	DataEnabled             bool       `json:"data_enabled"`
+	DataLimit               int        `json:"data_limit"`
+	DataMetering            string     `json:"data_metering"`
+	DateCreated             TwilioTime `json:"date_created"`
+	DateUpdated             TwilioTime `json:"date_updated"`
+	CommandsEnabled         bool       `json:"commands_enabled"`
+	CommandsUrl             url.URL    `json:"commands_url"`
+	CommandsMethod          string     `json:"commands_method"`
+	SmsCommandsEnabled      bool       `json:"sms_commands_enabled"`
+	SmsCommandsMethod       string     `json:"sms_commands_method"`
+	IPCommandsMethod        string     `json:"ip_commands_method"`
+	IPCommandsUrl           string     `json:"ip_commands_url"`
+	NetworkAccessProfileSid string     `json:"network_access_profile_sid"`
+}
+
+// FleetPage represents a page of Fleets.
+type FleetPage struct {
+	Meta   Meta     `json:"meta"`
+	Fleets []*Fleet `json:"fleets"`
+}
+
+type fleetPageIterator struct {
+	p *PageIterator
+}
+
+// Create creates a new SuperSim Fleet with the data provided, or returns an error.
+func (s *SuperSimService) CreateFleet(ctx context.Context, data url.Values) (*Fleet, error) {
+	fleet := new(Fleet)
+	err := s.client.CreateResource(ctx, fleetPathPart, data, fleet)
+	return fleet, err
+}
+
+// Get finds a single SuperSim Fleet by its sid, or returns an error.
+func (s *SuperSimService) GetFleet(ctx context.Context, sid string) (*Fleet, error) {
+	fleet := new(Fleet)
+	err := s.client.GetResource(ctx, fleetPathPart, sid, fleet)
+	return fleet, err
+}
+
+// GetPage returns a single Page of fleets, filtered by data.
+//
+// See https://www.twilio.com/docs/iot/supersim/api/fleet-resource#read-multiple-fleet-resources.
+func (s *SuperSimService) GetFleetPage(ctx context.Context, data url.Values) (*FleetPage, error) {
+	return s.GetFleetPageIterator(data).Next(ctx)
+}
+
+// GetFleetPageIterator returns a fleetPageIterator with the given page
+// filters. Call iterator.Next() to get the first page of resources (and again
+// to retrieve subsequent pages).
+func (s *SuperSimService) GetFleetPageIterator(data url.Values) *fleetPageIterator {
+	iter := NewPageIterator(s.client, data, fleetPathPart)
+	return &fleetPageIterator{
+		p: iter,
+	}
+}
+
+// Next returns the next page of resources. If there are no more resources,
+// NoMoreResults is returned.
+func (s *fleetPageIterator) Next(ctx context.Context) (*FleetPage, error) {
+	ap := new(FleetPage)
+	err := s.p.Next(ctx, ap)
+	if err != nil {
+		return nil, err
+	}
+	s.p.SetNextPageURI(ap.Meta.NextPageURL)
+	return ap, nil
+}
+
+type UsageRecord struct {
+	AccountSid   string      `json:"account_sid"`
+	SimSid       string      `json:"sim_sid"`
+	FleetSid     string      `json:"fleet_sid"`
+	NetworkSid   string      `json:"network_sid"`
+	DataUpload   int         `json:"data_upload"`
+	DataDownload int         `json:"data_download"`
+	DataTotal    int         `json:"data_total"`
+	IsoCountry   string      `json:"iso_country"`
+	Period       UsagePeriod `json:"period"`
+}
+
+// UsageRecordPage represents a page of UsageRecords.
+type UsageRecordPage struct {
+	Meta         Meta           `json:"meta"`
+	UsageRecords []*UsageRecord `json:"usage_records"`
+}
+
+type UsageRecordPageIterator struct {
+	p *PageIterator
+}
+
+// Get finds a single UsageRecord by its sid, or returns an error.
+func (s *SuperSimService) GetUsageRecord(ctx context.Context, sid string) (*UsageRecord, error) {
+	usageRecord := new(UsageRecord)
+	err := s.client.GetResource(ctx, usageRecordPathPart, sid, usageRecord)
+	return usageRecord, err
+}
+
+// GetPage returns a single Page of UsageRecords, filtered by data.
+//
+// See https://www.twilio.com/docs/iot/supersim/api/usage-record-resource#read-usagerecord-resources.
+func (s *SuperSimService) GetUsageRecordPage(ctx context.Context, data url.Values) (*UsageRecordPage, error) {
+	return s.GetUsageRecordPageIterator(data).Next(ctx)
+}
+
+// GetPageIterator returns a UsageRecordPageIterator with the given page
+// filters. Call iterator.Next() to get the first page of resources (and again
+// to retrieve subsequent pages).
+func (s *SuperSimService) GetUsageRecordPageIterator(data url.Values) *UsageRecordPageIterator {
+	iter := NewPageIterator(s.client, data, usageRecordPathPart)
+	return &UsageRecordPageIterator{
+		p: iter,
+	}
+}
+
+// Next returns the next page of resources. If there are no more resources,
+// NoMoreResults is returned.
+func (s *UsageRecordPageIterator) Next(ctx context.Context) (*UsageRecordPage, error) {
+	ap := new(UsageRecordPage)
+	err := s.p.Next(ctx, ap)
+	if err != nil {
+		return nil, err
+	}
+	s.p.SetNextPageURI(ap.Meta.NextPageURL)
+	return ap, nil
+}

--- a/super_sim.go
+++ b/super_sim.go
@@ -27,7 +27,7 @@ type SuperSim struct {
 
 // SuperSimPage represents a page of SuperSims.
 type SuperSimPage struct {
-	Meta      Meta        `json:"meta"`
+	Meta   Meta     `json:"meta"`
 	SuperSims []*SuperSim `json:"sims"`
 }
 

--- a/super_sim_networks.go
+++ b/super_sim_networks.go
@@ -1,0 +1,211 @@
+package twilio
+
+import (
+	"context"
+	"net/url"
+)
+
+const networkPathPart = "Networks"
+const napPathPart = "NetworkAccessProfiles"
+
+type NetworkService struct {
+	client *Client
+}
+
+type Network struct {
+	Sid          string        `json:"sid"`
+	Url          string        `json:"url"`
+	FriendlyName string        `json:"friendly_name"`
+	IsoCountry   string        `json:"iso_country"`
+	Identifiers  []interface{} `json:"identifiers"`
+}
+
+// NetworkPage represents a page of Networks.
+type NetworkPage struct {
+	Meta   Meta       `json:"meta"`
+	Fleets []*Network `json:"networks"`
+}
+
+type networkPageIterator struct {
+	p *PageIterator
+}
+
+// Get finds a single Network by its sid, or returns an error.
+func (s *NetworkService) GetNetwork(ctx context.Context, sid string) (*Network, error) {
+	network := new(Network)
+	err := s.client.GetResource(ctx, networkPathPart, sid, network)
+	return network, err
+}
+
+// GetPage returns a single Page of Networks, filtered by data.
+//
+// See https://www.twilio.com/docs/iot/supersim/api/network-resource?code-sample=code-fetch-a-network-resource.
+func (s *NetworkService) GetNetworkPage(ctx context.Context, data url.Values) (*NetworkPage, error) {
+	return s.GetNetworkPageIterator(data).Next(ctx)
+}
+
+// GetPageIterator returns a networkPageIterator with the given page
+// filters. Call iterator.Next() to get the first page of resources (and again
+// to retrieve subsequent pages).
+func (s *NetworkService) GetNetworkPageIterator(data url.Values) *networkPageIterator {
+	iter := NewPageIterator(s.client, data, networkPathPart)
+	return &networkPageIterator{
+		p: iter,
+	}
+}
+
+// Next returns the next page of resources. If there are no more resources,
+// NoMoreResults is returned.
+func (s *networkPageIterator) Next(ctx context.Context) (*NetworkPage, error) {
+	ap := new(NetworkPage)
+	err := s.p.Next(ctx, ap)
+	if err != nil {
+		return nil, err
+	}
+	s.p.SetNextPageURI(ap.Meta.NextPageURL)
+	return ap, nil
+}
+
+type NetworkAccessProfile struct {
+	Sid         string            `json:"sid"`
+	UniqueName  string            `json:"unique_name"`
+	AccountSid  string            `json:"account_sid"`
+	DateCreated TwilioTime        `json:"date_created"`
+	DateUpdated TwilioTime        `json:"date_updated"`
+	Url         string            `json:"url"`
+	Links       map[string]string `json:"links"`
+}
+
+// NAPPage represents a page of Network Access Profiles.
+type NAPPage struct {
+	Meta                  Meta                    `json:"meta"`
+	NetworkAccessProfiles []*NetworkAccessProfile `json:"networks"`
+}
+
+type NAPPageIterator struct {
+	p *PageIterator
+}
+
+// Create creates a new NetworkAccessProfile with the data provided, or returns an error.
+func (s *NetworkService) CreateNetworkAccessProfile(ctx context.Context, data url.Values) (*NetworkAccessProfile, error) {
+	networkAccessProfile := new(NetworkAccessProfile)
+	err := s.client.CreateResource(ctx, napPathPart, data, networkAccessProfile)
+	return networkAccessProfile, err
+}
+
+// Get finds a single NetworkAccessProfile by its sid, or returns an error.
+func (s *NetworkService) GetNetworkAccessProfile(ctx context.Context, sid string) (*NetworkAccessProfile, error) {
+	networkAccessProfile := new(NetworkAccessProfile)
+	err := s.client.GetResource(ctx, napPathPart, sid, networkAccessProfile)
+	return networkAccessProfile, err
+}
+
+// Update updates the specified NetworkAccessProfile with the data provided, or returns an error.
+func (s *NetworkService) UpdateNetworkAccessProfile(ctx context.Context, sid string, data url.Values) (*NetworkAccessProfile, error) {
+	networkAccessProfile := new(NetworkAccessProfile)
+	err := s.client.UpdateResource(ctx, napPathPart, sid, data, networkAccessProfile)
+	return networkAccessProfile, err
+}
+
+// GetPage returns a single Page of NetworkAccessProfiles, filtered by data.
+//
+// See https://www.twilio.com/docs/iot/supersim/api/networkaccessprofile-resource#read-multiple-networkaccessprofile-resources.
+func (s *NetworkService) GetNetworkAccessProfilePage(ctx context.Context, data url.Values) (*NAPPage, error) {
+	return s.GetNAPPageIterator(data).Next(ctx)
+}
+
+// GetPageIterator returns a NAPPageIterator with the given page
+// filters. Call iterator.Next() to get the first page of resources (and again
+// to retrieve subsequent pages).
+func (s *NetworkService) GetNAPPageIterator(data url.Values) *NAPPageIterator {
+	iter := NewPageIterator(s.client, data, networkPathPart)
+	return &NAPPageIterator{
+		p: iter,
+	}
+}
+
+// Next returns the next page of resources. If there are no more resources,
+// NoMoreResults is returned.
+func (s *NAPPageIterator) Next(ctx context.Context) (*NAPPage, error) {
+	ap := new(NAPPage)
+	err := s.p.Next(ctx, ap)
+	if err != nil {
+		return nil, err
+	}
+	s.p.SetNextPageURI(ap.Meta.NextPageURL)
+	return ap, nil
+}
+
+type NAPNetwork struct {
+	Sid          string        `json:"sid"`
+	NAPSid       string        `json:"network_access_profile_sid"`
+	FriendlyName string        `json:"friendly_name"`
+	ISOCountry   string        `json:"iso_country"`
+	Identifiers  []interface{} `json:"identifiers"`
+	Url          string        `json:"url"`
+}
+
+// NAPNetworkPage represents a page of NAPNetworks.
+type NAPNetworkPage struct {
+	Meta        Meta          `json:"meta"`
+	NAPNetworks []*NAPNetwork `json:"networks"`
+}
+
+type NAPNetworkPageIterator struct {
+	p *PageIterator
+}
+
+// Create creates a new NAP Network associated with the NetworkAccessProfile provided, or returns an error.
+func (s *NetworkService) CreateNAPNetwork(ctx context.Context, napSid string, data url.Values) (*NetworkAccessProfile, error) {
+	networkAccessProfile := new(NetworkAccessProfile)
+	err := s.client.CreateResource(ctx, napPathPart+"/"+napSid, data, networkAccessProfile)
+	return networkAccessProfile, err
+}
+
+// Get finds a single NAP Network, or returns an error.
+func (s *NetworkService) GetNAPNetwork(ctx context.Context, napSid, sid string) (*NetworkAccessProfile, error) {
+	networkAccessProfile := new(NetworkAccessProfile)
+	err := s.client.GetResource(ctx, napPathPart+"/"+napSid, sid, networkAccessProfile)
+	return networkAccessProfile, err
+}
+
+// Update updates a single NAP Network with the data provided, or returns an error.
+func (s *NetworkService) UpdateNAPNetwork(ctx context.Context, napSid, sid string, data url.Values) (*NetworkAccessProfile, error) {
+	networkAccessProfile := new(NetworkAccessProfile)
+	err := s.client.UpdateResource(ctx, napPathPart+"/"+napSid, sid, data, networkAccessProfile)
+	return networkAccessProfile, err
+}
+
+// Delete deletes the provided NAP Network, or returns an error.
+func (s *NetworkService) DeleteNAPNetwork(ctx context.Context, napSid, sid string, data url.Values) error {
+	return s.client.DeleteResource(ctx, napPathPart+"/"+napSid, sid)
+}
+
+// GetPage returns a single Page of NAPNetworks, filtered by data.
+//
+// See https://www.twilio.com/docs/iot/supersim/api/networkaccessprofile-resource/network-resource#read-multiple-networkaccessprofile-network-resources.
+func (s *NetworkService) GetNAPNetworkPage(ctx context.Context, napSid string, data url.Values) (*NAPNetworkPage, error) {
+	return s.GetNAPNetworkPageIterator(napPathPart+"/"+napSid, data).Next(ctx)
+}
+
+// GetPageIterator returns a NAPNetworkPageIterator with the given page
+// filters. Call iterator.Next() to get the first page of resources (and again
+// to retrieve subsequent pages).
+func (s *NetworkService) GetNAPNetworkPageIterator(napSid string, data url.Values) *NAPNetworkPageIterator {
+	iter := NewPageIterator(s.client, data, napPathPart+"/"+napSid)
+	return &NAPNetworkPageIterator{
+		p: iter,
+	}
+}
+
+// Next returns the next page of resources. If there are no more resources,
+// NoMoreResults is returned.
+func (s *NAPNetworkPageIterator) Next(ctx context.Context) (*NAPNetworkPage, error) {
+	ap := new(NAPNetworkPage)
+	err := s.p.Next(ctx, ap)
+	if err != nil {
+		return nil, err
+	}
+	s.p.SetNextPageURI(ap.Meta.NextPageURL)
+	return ap, nil
+}

--- a/super_sim_networks_test.go
+++ b/super_sim_networks_test.go
@@ -1,0 +1,36 @@
+package twilio
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestGetNetworkPage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping HTTP request in short mode")
+	}
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	page, err := envClient.SuperSim.Networks.GetNetworkPage(ctx, url.Values{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertPageExpected(t, page.Meta)
+}
+
+func TestGetNAPPage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping HTTP request in short mode")
+	}
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	page, err := envClient.SuperSim.Networks.GetNetworkAccessProfilePage(ctx, url.Values{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertPageExpected(t, page.Meta)
+}

--- a/super_sim_test.go
+++ b/super_sim_test.go
@@ -1,0 +1,131 @@
+package twilio
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+)
+
+func assertSuperSimExpected(t *testing.T, sim *SuperSim) {
+	if sim == nil {
+		t.Fatal("SuperSim unexpectedly nil")
+	}
+	if sim.Sid == "" {
+		t.Error("expected Sid to be populated")
+	}
+	if sim.Status == "" {
+		t.Error("expected Status to be populated")
+	}
+	if !sim.DateCreated.Valid {
+		t.Error("expected DateCreated to be valid")
+	}
+	if !sim.DateUpdated.Valid {
+		t.Error("expected DateUpdated to be valid")
+	}
+	if sim.AccountSid == "" {
+		t.Error("expected AccountSid to be populated")
+	}
+	if sim.Iccid == "" {
+		t.Error("expected Iccid to be populated")
+	}
+	if sim.Url == "" {
+		t.Error("expected Url to be populated")
+	}
+}
+
+func assertUsageRecordExpected(t *testing.T, usageRecord *UsageRecord) {
+	if usageRecord == nil {
+		t.Fatal("SuperSim unexpectedly nil")
+	}
+	if usageRecord.SimSid == "" {
+		t.Error("expected SimSid to be populated")
+	}
+	if usageRecord.AccountSid == "" {
+		t.Error("expected AccountSid to be populated")
+	}
+	if usageRecord.FleetSid == "" {
+		t.Error("expected FleetSid to be populated")
+	}
+	if usageRecord.NetworkSid == "" {
+		t.Error("expected NetworkSid to be populated")
+	}
+	if usageRecord.IsoCountry == "" {
+		t.Error("expected IsoCountry to be populated")
+	}
+	if usageRecord.FleetSid == "" {
+		t.Error("expected FleetSid to be populated")
+	}
+}
+
+func assertPageExpected(t *testing.T, meta Meta) {
+	if meta.FirstPageURL == "" {
+		t.Error("expected FirstPageURL to be populated")
+	}
+	if meta.Key == "" {
+		t.Error("expected Key to be populated")
+	}
+	if meta.PageSize == 0 {
+		t.Error("expected default PageSize, got 0")
+	}
+}
+
+func TestGetSuperSim(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping HTTP request in short mode")
+	}
+	t.Parallel()
+	sid := "HS08d349f2f43fe4ac045905cbfd4e04e6"
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	superSim, err := envClient.SuperSim.SuperSims.Get(ctx, sid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertSuperSimExpected(t, superSim)
+	if superSim.Sid != sid {
+		t.Errorf("expected Sid to equal %s, got %s", sid, superSim.Sid)
+	}
+}
+
+func TestGetSuperSimPage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping HTTP request in short mode")
+	}
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	page, err := envClient.SuperSim.SuperSims.GetPage(ctx, url.Values{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertPageExpected(t, page.Meta)
+}
+
+func TestGetFleetPage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping HTTP request in short mode")
+	}
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	page, err := envClient.SuperSim.SuperSims.GetFleetPage(ctx, url.Values{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertPageExpected(t, page.Meta)
+}
+
+func TestGetUsageRecordPage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping HTTP request in short mode")
+	}
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	page, err := envClient.SuperSim.SuperSims.GetUsageRecordPage(ctx, url.Values{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertPageExpected(t, page.Meta)
+}

--- a/super_sim_test.go
+++ b/super_sim_test.go
@@ -34,6 +34,7 @@ func assertSuperSimExpected(t *testing.T, sim *SuperSim) {
 	}
 }
 
+<<<<<<< HEAD
 func assertUsageRecordExpected(t *testing.T, usageRecord *UsageRecord) {
 	if usageRecord == nil {
 		t.Fatal("SuperSim unexpectedly nil")
@@ -58,6 +59,8 @@ func assertUsageRecordExpected(t *testing.T, usageRecord *UsageRecord) {
 	}
 }
 
+=======
+>>>>>>> d96635c (twilio: add new SuperSim client)
 func assertPageExpected(t *testing.T, meta Meta) {
 	if meta.FirstPageURL == "" {
 		t.Error("expected FirstPageURL to be populated")

--- a/super_sim_test.go
+++ b/super_sim_test.go
@@ -34,33 +34,6 @@ func assertSuperSimExpected(t *testing.T, sim *SuperSim) {
 	}
 }
 
-<<<<<<< HEAD
-func assertUsageRecordExpected(t *testing.T, usageRecord *UsageRecord) {
-	if usageRecord == nil {
-		t.Fatal("SuperSim unexpectedly nil")
-	}
-	if usageRecord.SimSid == "" {
-		t.Error("expected SimSid to be populated")
-	}
-	if usageRecord.AccountSid == "" {
-		t.Error("expected AccountSid to be populated")
-	}
-	if usageRecord.FleetSid == "" {
-		t.Error("expected FleetSid to be populated")
-	}
-	if usageRecord.NetworkSid == "" {
-		t.Error("expected NetworkSid to be populated")
-	}
-	if usageRecord.IsoCountry == "" {
-		t.Error("expected IsoCountry to be populated")
-	}
-	if usageRecord.FleetSid == "" {
-		t.Error("expected FleetSid to be populated")
-	}
-}
-
-=======
->>>>>>> d96635c (twilio: add new SuperSim client)
 func assertPageExpected(t *testing.T, meta Meta) {
 	if meta.FirstPageURL == "" {
 		t.Error("expected FirstPageURL to be populated")


### PR DESCRIPTION
Add `NetworkService` to handle API calls for `SuperSim` `Network` `NetworkAccessProfile` and `NAPNetwork` resources. The `SuperSim` client initializes the `NetworkService` for use under the `supersim` base URL.

This PR is built off of https://github.com/meterup/twilio-go/pull/1, which should be merged first.