### PR TITLE
twilio: add new NetworkService to SuperSim client

### DIFF
--- a/http.go
+++ b/http.go
@@ -133,6 +133,7 @@ type Client struct {
 
 	// NewSuperSimClient initializes these services
 	SuperSims *SuperSimService
+	Networks  *NetworkService
 
 	// NewNotifyClient initializes these services
 	Credentials *NotifyCredentialsService
@@ -254,6 +255,7 @@ func NewSuperSimClient(accountSid string, authToken string, httpClient *http.Cli
 	c := newNewClient(accountSid, authToken, SuperSimBaseUrl, httpClient)
 	c.APIVersion = SuperSimVersion
 	c.SuperSims = &SuperSimService{client: c}
+	c.Networks = &NetworkService{client: c}
 	return c
 }
 

--- a/responses_test.go
+++ b/responses_test.go
@@ -3656,5 +3656,170 @@ var usageRecordResponse = []byte(`
 }
 `)
 
+var networkResponse = []byte(`
+{
+  "friendly_name": "AT&T",
+  "iso_country": "US",
+  "identifiers": [
+    {
+      "mcc": "310",
+      "mnc": "410"
+    }
+  ],
+  "sid": "HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "url": "https://supersim.twilio.com/v1/Networks/HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+}
+`)
+
+var networkPageResponse = []byte(`
+{
+  "meta": {
+    "first_page_url": "https://supersim.twilio.com/v1/Networks?IsoCountry=US&Mnc=410&Mcc=310&PageSize=50&Page=0",
+    "key": "networks",
+    "next_page_url": "https://supersim.twilio.com/v1/Networks?IsoCountry=US&Mnc=410&Mcc=310&PageSize=50&Page=1",
+    "page": 0,
+    "page_size": 50,
+    "previous_page_url": "https://supersim.twilio.com/v1/Networks?IsoCountry=US&Mnc=410&Mcc=310&PageSize=50&Page=0",
+    "url": "https://supersim.twilio.com/v1/Networks?IsoCountry=US&Mnc=410&Mcc=310&PageSize=50&Page=0"
+  },
+  "networks": [
+    {
+      "friendly_name": "AT&T",
+      "iso_country": "US",
+      "identifiers": [
+        {
+          "mcc": "310",
+          "mnc": "410"
+        }
+      ],
+      "sid": "HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "url": "https://supersim.twilio.com/v1/Networks/HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    },
+    {
+      "friendly_name": "AT&T",
+      "iso_country": "US",
+      "identifiers": [
+        {
+          "mcc": "310",
+          "mnc": "410"
+        }
+      ],
+      "sid": "HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "url": "https://supersim.twilio.com/v1/Networks/HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    }
+  ]
+}
+`)
+
+var networkAccessProfileResponse = []byte(`
+{
+  "unique_name": "My Network Access Profile",
+  "sid": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "date_created": "2020-05-01T20:00:00Z",
+  "date_updated": "2020-05-01T20:00:00Z",
+  "url": "https://supersim.twilio.com/v1/NetworkAccessProfiles/HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "links": {
+    "networks": "https://supersim.twilio.com/v1/NetworkAccessProfiles/HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Networks"
+  }
+}
+`)
+
+var networkAccessProfilePageResponse = []byte(`
+{
+  "network_access_profiles": [
+    {
+      "unique_name": "My Network Access Profile",
+      "sid": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "date_created": "2020-05-01T20:00:00Z",
+      "date_updated": "2020-05-01T20:00:00Z",
+      "url": "https://supersim.twilio.com/v1/NetworkAccessProfiles/HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "links": {
+        "networks": "https://supersim.twilio.com/v1/NetworkAccessProfiles/HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Networks"
+      }
+    },
+    {
+      "unique_name": "My Network Access Profile",
+      "sid": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "account_sid": "ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "date_created": "2020-05-01T20:00:00Z",
+      "date_updated": "2020-05-01T20:00:00Z",
+      "url": "https://supersim.twilio.com/v1/NetworkAccessProfiles/HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "links": {
+        "networks": "https://supersim.twilio.com/v1/NetworkAccessProfiles/HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Networks"
+      }
+    }
+  ],
+  "meta": {
+    "first_page_url": "https://supersim.twilio.com/v1/NetworkAccessProfiles?PageSize=50&Page=0",
+    "key": "network_access_profiles",
+    "next_page_url": "https://supersim.twilio.com/v1/NetworkAccessProfiles?PageSize=50&Page=1",
+    "page": 0,
+    "page_size": 50,
+    "previous_page_url": "https://supersim.twilio.com/v1/NetworkAccessProfiles?PageSize=50&Page=0",
+    "url": "https://supersim.twilio.com/v1/NetworkAccessProfiles?PageSize=50&Page=0"
+  }
+}
+`)
+
+var napNetworkResponse = []byte(`
+{
+  "sid": "HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "network_access_profile_sid": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+  "friendly_name": "AT&T",
+  "iso_country": "us",
+  "identifiers": [
+    {
+      "mcc": "310",
+      "mnc": "410"
+    }
+  ],
+  "url": "https://supersim.twilio.com/v1/NetworkAccessProfiles/HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Networks/HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+}
+`)
+
+var napNetworkPageResponse = []byte(`
+{
+  "meta": {
+    "first_page_url": "https://supersim.twilio.com/v1/NetworkAccessProfiles/HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Networks?PageSize=50&Page=0",
+    "key": "networks",
+    "next_page_url": "https://supersim.twilio.com/v1/NetworkAccessProfiles/HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Networks?PageSize=50&Page=1",
+    "page": 0,
+    "page_size": 50,
+    "previous_page_url": "https://supersim.twilio.com/v1/NetworkAccessProfiles/HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Networks?PageSize=50&Page=0",
+    "url": "https://supersim.twilio.com/v1/NetworkAccessProfiles/HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Networks?PageSize=50&Page=0"
+  },
+  "networks": [
+    {
+      "sid": "HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "network_access_profile_sid": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "friendly_name": "AT&T",
+      "iso_country": "us",
+      "identifiers": [
+        {
+          "mcc": "310",
+          "mnc": "410"
+        }
+      ],
+      "url": "https://supersim.twilio.com/v1/NetworkAccessProfiles/HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Networks/HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    },
+    {
+      "sid": "HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "network_access_profile_sid": "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+      "friendly_name": "AT&T",
+      "iso_country": "us",
+      "identifiers": [
+        {
+          "mcc": "310",
+          "mnc": "410"
+        }
+      ],
+      "url": "https://supersim.twilio.com/v1/NetworkAccessProfiles/HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX/Networks/HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    }
+  ]
+}
+`)
+
 const from = "+19253920364"
 const to = "+19253920364"

--- a/super_sim_networks.go
+++ b/super_sim_networks.go
@@ -1,0 +1,212 @@
+package twilio
+
+import (
+	"context"
+	"net/url"
+)
+
+const networkPathPart = "Networks"
+const napPathPart = "NetworkAccessProfiles"
+
+type NetworkService struct {
+	client *Client
+}
+
+type Network struct {
+	Sid          string        `json:"sid"`
+	Url          string        `json:"url"`
+	FriendlyName string        `json:"friendly_name"`
+	// Alpha-2 ISO Country Code
+	IsoCountry   string        `json:"iso_country"`
+	Identifiers  []interface{} `json:"identifiers"`
+}
+
+// NetworkPage represents a page of Networks.
+type NetworkPage struct {
+	Meta   Meta       `json:"meta"`
+	Networks []*Network `json:"networks"`
+}
+
+type networkPageIterator struct {
+	p *PageIterator
+}
+
+// GetNetwork finds a single Network by its sid, or returns an error.
+func (s *NetworkService) GetNetwork(ctx context.Context, sid string) (*Network, error) {
+	network := new(Network)
+	err := s.client.GetResource(ctx, networkPathPart, sid, network)
+	return network, err
+}
+
+// GetNetworkPage returns a single Page of Networks, filtered by data.
+//
+// See https://www.twilio.com/docs/iot/supersim/api/network-resource?code-sample=code-fetch-a-network-resource.
+func (s *NetworkService) GetNetworkPage(ctx context.Context, data url.Values) (*NetworkPage, error) {
+	return s.GetNetworkPageIterator(data).Next(ctx)
+}
+
+// GetNetworkPageIterator returns a networkPageIterator with the given page
+// filters. Call iterator.Next() to get the first page of resources (and again
+// to retrieve subsequent pages).
+func (s *NetworkService) GetNetworkPageIterator(data url.Values) *networkPageIterator {
+	iter := NewPageIterator(s.client, data, networkPathPart)
+	return &networkPageIterator{
+		p: iter,
+	}
+}
+
+// Next returns the next page of resources. If there are no more resources,
+// NoMoreResults is returned.
+func (s *networkPageIterator) Next(ctx context.Context) (*NetworkPage, error) {
+	ap := new(NetworkPage)
+	err := s.p.Next(ctx, ap)
+	if err != nil {
+		return nil, err
+	}
+	s.p.SetNextPageURI(ap.Meta.NextPageURL)
+	return ap, nil
+}
+
+type NetworkAccessProfile struct {
+	Sid         string            `json:"sid"`
+	UniqueName  string            `json:"unique_name"`
+	AccountSid  string            `json:"account_sid"`
+	DateCreated TwilioTime        `json:"date_created"`
+	DateUpdated TwilioTime        `json:"date_updated"`
+	Url         string            `json:"url"`
+	Links       map[string]string `json:"links"`
+}
+
+// NAPPage represents a page of Network Access Profiles.
+type NAPPage struct {
+	Meta                  Meta                    `json:"meta"`
+	NetworkAccessProfiles []*NetworkAccessProfile `json:"network_access_profiles"`
+}
+
+type NAPPageIterator struct {
+	p *PageIterator
+}
+
+// CreateNetworkAccessProfile creates a new NetworkAccessProfile with the data provided, or returns an error.
+func (s *NetworkService) CreateNetworkAccessProfile(ctx context.Context, data url.Values) (*NetworkAccessProfile, error) {
+	networkAccessProfile := new(NetworkAccessProfile)
+	err := s.client.CreateResource(ctx, napPathPart, data, networkAccessProfile)
+	return networkAccessProfile, err
+}
+
+// GetNetworkAccessProfile finds a single NetworkAccessProfile by its sid, or returns an error.
+func (s *NetworkService) GetNetworkAccessProfile(ctx context.Context, sid string) (*NetworkAccessProfile, error) {
+	networkAccessProfile := new(NetworkAccessProfile)
+	err := s.client.GetResource(ctx, napPathPart, sid, networkAccessProfile)
+	return networkAccessProfile, err
+}
+
+// UpdateNetworkAccessProfile updates the specified NetworkAccessProfile with the data provided, or returns an error.
+func (s *NetworkService) UpdateNetworkAccessProfile(ctx context.Context, sid string, data url.Values) (*NetworkAccessProfile, error) {
+	networkAccessProfile := new(NetworkAccessProfile)
+	err := s.client.UpdateResource(ctx, napPathPart, sid, data, networkAccessProfile)
+	return networkAccessProfile, err
+}
+
+// GetNetworkAccessProfilePage returns a single Page of NetworkAccessProfiles, filtered by data.
+//
+// See https://www.twilio.com/docs/iot/supersim/api/networkaccessprofile-resource#read-multiple-networkaccessprofile-resources.
+func (s *NetworkService) GetNetworkAccessProfilePage(ctx context.Context, data url.Values) (*NAPPage, error) {
+	return s.GetNAPPageIterator(data).Next(ctx)
+}
+
+// GetNAPPageIterator returns a NAPPageIterator with the given page
+// filters. Call iterator.Next() to get the first page of resources (and again
+// to retrieve subsequent pages).
+func (s *NetworkService) GetNAPPageIterator(data url.Values) *NAPPageIterator {
+	iter := NewPageIterator(s.client, data, networkPathPart)
+	return &NAPPageIterator{
+		p: iter,
+	}
+}
+
+// Next returns the next page of resources. If there are no more resources,
+// NoMoreResults is returned.
+func (s *NAPPageIterator) Next(ctx context.Context) (*NAPPage, error) {
+	ap := new(NAPPage)
+	err := s.p.Next(ctx, ap)
+	if err != nil {
+		return nil, err
+	}
+	s.p.SetNextPageURI(ap.Meta.NextPageURL)
+	return ap, nil
+}
+
+type NAPNetwork struct {
+	Sid                     string        `json:"sid"`
+	NetworkAccessProfileSid string        `json:"network_access_profile_sid"`
+	FriendlyName            string        `json:"friendly_name"`
+	ISOCountry              string        `json:"iso_country"`
+	Identifiers             []interface{} `json:"identifiers"`
+	Url                     string        `json:"url"`
+}
+
+// NAPNetworkPage represents a page of NAPNetworks.
+type NAPNetworkPage struct {
+	Meta        Meta          `json:"meta"`
+	NAPNetworks []*NAPNetwork `json:"networks"`
+}
+
+type NAPNetworkPageIterator struct {
+	p *PageIterator
+}
+
+// CreateNAPNetwork creates a new NAP Network associated with the NetworkAccessProfile provided, or returns an error.
+func (s *NetworkService) CreateNAPNetwork(ctx context.Context, napSid string, data url.Values) (*NAPNetwork, error) {
+	networkAccessProfile := new(NAPNetwork)
+	err := s.client.CreateResource(ctx, napPathPart+"/"+napSid, data, networkAccessProfile)
+	return networkAccessProfile, err
+}
+
+// GetNAPNetwork finds a single NAP Network, or returns an error.
+func (s *NetworkService) GetNAPNetwork(ctx context.Context, napSid, sid string) (*NAPNetwork, error) {
+	networkAccessProfile := new(NAPNetwork)
+	err := s.client.GetResource(ctx, napPathPart+"/"+napSid, sid, networkAccessProfile)
+	return networkAccessProfile, err
+}
+
+// UpdateNAPNetwork updates a single NAP Network with the data provided, or returns an error.
+func (s *NetworkService) UpdateNAPNetwork(ctx context.Context, napSid, sid string, data url.Values) (*NAPNetwork, error) {
+	networkAccessProfile := new(NAPNetwork)
+	err := s.client.UpdateResource(ctx, napPathPart+"/"+napSid, sid, data, networkAccessProfile)
+	return networkAccessProfile, err
+}
+
+// DeleteNAPNetwork deletes the provided NAP Network, or returns an error.
+func (s *NetworkService) DeleteNAPNetwork(ctx context.Context, napSid, sid string, data url.Values) error {
+	return s.client.DeleteResource(ctx, napPathPart+"/"+napSid, sid)
+}
+
+// GetNAPNetworkPage returns a single Page of NAPNetworks, filtered by data.
+//
+// See https://www.twilio.com/docs/iot/supersim/api/networkaccessprofile-resource/network-resource#read-multiple-networkaccessprofile-network-resources.
+func (s *NetworkService) GetNAPNetworkPage(ctx context.Context, napSid string, data url.Values) (*NAPNetworkPage, error) {
+	return s.GetNAPNetworkPageIterator(napPathPart+"/"+napSid, data).Next(ctx)
+}
+
+// GetNAPNetworkPageIterator returns a NAPNetworkPageIterator with the given page
+// filters. Call iterator.Next() to get the first page of resources (and again
+// to retrieve subsequent pages).
+func (s *NetworkService) GetNAPNetworkPageIterator(napSid string, data url.Values) *NAPNetworkPageIterator {
+	iter := NewPageIterator(s.client, data, napPathPart+"/"+napSid)
+	return &NAPNetworkPageIterator{
+		p: iter,
+	}
+}
+
+// Next returns the next page of resources. If there are no more resources,
+// NoMoreResults is returned.
+func (s *NAPNetworkPageIterator) Next(ctx context.Context) (*NAPNetworkPage, error) {
+	ap := new(NAPNetworkPage)
+	err := s.p.Next(ctx, ap)
+	if err != nil {
+		return nil, err
+	}
+	s.p.SetNextPageURI(ap.Meta.NextPageURL)
+	return ap, nil
+}

--- a/super_sim_networks_test.go
+++ b/super_sim_networks_test.go
@@ -1,0 +1,253 @@
+package twilio
+
+import (
+	"context"
+	"net/url"
+	"testing"
+)
+
+func assertNetworkExpected(t *testing.T, network *Network) {
+	if network == nil {
+		t.Fatal("unexpected nil network")
+	}
+	if network.FriendlyName == "" {
+		t.Error("expected FriendlyName to be populated")
+	}
+	if network.IsoCountry == "" {
+		t.Error("expected IsoCountry to be populated")
+	}
+	if network.Identifiers == nil {
+		t.Error("expected Identifiers to be populated")
+	}
+	if network.Sid == "" {
+		t.Error("expected Sid to be populated")
+	}
+	if network.Url == "" {
+		t.Error("expected Url to be populated")
+	}
+}
+
+func assertNetworkAccessProfileExpected(t *testing.T, networkAccessProfile *NetworkAccessProfile) {
+	if networkAccessProfile == nil {
+		t.Fatal("unexpected nil network")
+	}
+	if networkAccessProfile.Sid == "" {
+		t.Error("expected Sid to be populated")
+	}
+	if networkAccessProfile.UniqueName == "" {
+		t.Error("expected UniqueName to be populated")
+	}
+	if networkAccessProfile.AccountSid == "" {
+		t.Error("expected AccountSid to be populated")
+	}
+	if !networkAccessProfile.DateCreated.Valid {
+		t.Error("expected DateCreated to be valid")
+	}
+	if !networkAccessProfile.DateUpdated.Valid {
+		t.Error("expected DateUpdated to be populated")
+	}
+	if networkAccessProfile.Url == "" {
+		t.Error("expected Url to be populated")
+	}
+	if networkAccessProfile.Links == nil {
+		t.Error("expected Links to be populated")
+	}
+}
+
+func assertNAPNetworkExpected(t *testing.T, napNetwork *NAPNetwork) {
+	if napNetwork == nil {
+		t.Fatal("unexpected nil network")
+	}
+	if napNetwork.Sid == "" {
+		t.Error("expected Sid to be populated")
+	}
+	if napNetwork.FriendlyName == "" {
+		t.Error("expected FriendlyName to be populated")
+	}
+	if napNetwork.NetworkAccessProfileSid == "" {
+		t.Error("expected NetworkAccessProfileSid to be populated")
+	}
+	if napNetwork.ISOCountry == "" {
+		t.Error("expected ISOCountry to be populated")
+	}
+	if napNetwork.Url == "" {
+		t.Error("expected Url to be populated")
+	}
+	if napNetwork.Identifiers == nil {
+		t.Error("expected Links to be populated")
+	}
+}
+
+func TestNetwork(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Get", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(networkResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network, err := client.SuperSim.Networks.GetNetwork(ctx, "89883070000123456789")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertNetworkExpected(t, network)
+	})
+
+	t.Run("GetPage", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(networkPageResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		resp, err := client.SuperSim.Networks.GetNetworkPage(ctx, url.Values{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(resp.Networks) != 2 {
+			t.Errorf("expected 2 networks, found %d", len(resp.Networks))
+		}
+		for _, network := range resp.Networks {
+			assertNetworkExpected(t, network)
+		}
+		assertPageExpected(t, resp.Meta)
+	})
+}
+
+func TestNetworkAccessProfile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Create", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(networkAccessProfileResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		networkAccessProfile, err := client.SuperSim.Networks.CreateNetworkAccessProfile(ctx, url.Values{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertNetworkAccessProfileExpected(t, networkAccessProfile)
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(networkAccessProfileResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		networkAccessProfile, err := client.SuperSim.Networks.GetNetworkAccessProfile(ctx, "89883070000123456789")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertNetworkAccessProfileExpected(t, networkAccessProfile)
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(networkAccessProfileResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		networkAccessProfile, err := client.SuperSim.Networks.UpdateNetworkAccessProfile(
+			ctx, "89883070000123456789", url.Values{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertNetworkAccessProfileExpected(t, networkAccessProfile)
+	})
+
+	t.Run("GetPage", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(networkAccessProfilePageResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		resp, err := client.SuperSim.Networks.GetNetworkAccessProfilePage(ctx, url.Values{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(resp.NetworkAccessProfiles) != 2 {
+			t.Errorf("expected 2 networks, found %d", len(resp.NetworkAccessProfiles))
+		}
+		for _, networkAccessProfile := range resp.NetworkAccessProfiles {
+			assertNetworkAccessProfileExpected(t, networkAccessProfile)
+		}
+		assertPageExpected(t, resp.Meta)
+	})
+}
+
+func TestNAPNetwork(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Create", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(napNetworkResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		napNetwork, err := client.SuperSim.Networks.CreateNAPNetwork(
+			ctx, "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", url.Values{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertNAPNetworkExpected(t, napNetwork)
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(napNetworkResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		napNetwork, err := client.SuperSim.Networks.GetNAPNetwork(
+			ctx, "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertNAPNetworkExpected(t, napNetwork)
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(napNetworkResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		napNetwork, err := client.SuperSim.Networks.UpdateNAPNetwork(
+			ctx, "HAXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", "HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", url.Values{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertNAPNetworkExpected(t, napNetwork)
+	})
+
+	t.Run("GetPage", func(t *testing.T) {
+		t.Parallel()
+		client, s := getServer(napNetworkPageResponse)
+		defer s.Close()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		resp, err := client.SuperSim.Networks.GetNAPNetworkPage(ctx, "HWXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", url.Values{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(resp.NAPNetworks) != 2 {
+			t.Errorf("expected 2 networks, found %d", len(resp.NAPNetworks))
+		}
+		for _, napNetwork := range resp.NAPNetworks {
+			assertNAPNetworkExpected(t, napNetwork)
+		}
+		assertPageExpected(t, resp.Meta)
+	})
+}


### PR DESCRIPTION
Add `NetworkService` to handle API calls for `SuperSim` `Network` `NetworkAccessProfile` and `NAPNetwork` resources. The `SuperSim` client initializes the `NetworkService` for use under the supersim base URL.