### PR TITLE
types: add missing supersim statuses

### DIFF
--- a/types.go
+++ b/types.go
@@ -302,6 +302,13 @@ const StatusProcessing = Status("processing")
 
 const StatusRead = Status("read")
 
+// Super SIM statuses
+
+const StatusNew = Status("new")
+const StatusReady = Status("ready")
+const StatusScheduled = Status("scheduled")
+const StatusInactive = Status("inactive")
+
 // Shared statuses
 
 const StatusActive = Status("active")


### PR DESCRIPTION
Add 'new, 'ready', 'scheduled' and 'inactive' statuses for the supersim API.
https://www.twilio.com/docs/iot/supersim/how-to-determine-a-super-sims-status